### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# CORTX Security Policy
+
+We take the security of the CORTX project seriously. If you find any security vulnerabilities in any of the CORTX-owned source code managed via our [GitHub Organisation](https://github.com/Seagate) repositories, please report it to us as described below.
+
+## Reporting Security Issues
+
+:warning: **Please do not publicly report any security vulnerabilities via GitHub issues.**
+
+If you have concerns or questions, please email us at [cortx-questions@seagate.com](mailto:cortx-questionse@seagate.com). 
+
+To report an actual vulnerability, please use the "[Seagate Responsible Vulnerability Disclosure Policy](https://www.seagate.com/legal-privacy/responsible-vulnerability-disclosure-policy/)"
+ 
+
+### Reporting Format
+
+To make your reporting meaningful and help us understand the nature and scope of the issue, please include as much information as possible. 
+
+### Preferred Languages
+
+We prefer all communications to be in English.


### PR DESCRIPTION
Add a default Security policy for all Seagate projects. This file was copied from https://github.com/Seagate/cortx/blob/main/SECURITY.md.

-----
[View rendered SECURITY.md](https://github.com/keithpine/.github/blob/patch-1/SECURITY.md)