### PR TITLE
Making the Issue templates be more consistent

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report problems and issues
+description: Report problems and issues.
 labels: [bug]
 
 body:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report problems and issues.
+description: Report problems and issues specific to this CORTX component. Please first check to make sure this has not yet been reported.
 labels: [bug]
 
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Feature request for overall CORTX project
     url: https://github.com/Seagate/cortx/issues/new?assignees=&labels=enhancement&template=enhancement.yml

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Feature/improvement request for overall CORTX project
+  - name: Feature request for overall CORTX project
     url: https://github.com/Seagate/cortx/issues/new?assignees=&labels=enhancement&template=enhancement.yml
-    about: Want to suggest an idea for CORTX? Create a feature/improvement request.
-  - name: CORTX Questions and Support
+    about: Want to suggest an idea for the overall CORTX project? Create a feature/improvement request.
+  - name: CORTX community questions and support via GitHub Discussions
     url: https://github.com/Seagate/cortx/discussions
-    about: Have questions or need support for CORTX for anything that isn't a bug report? Go ahead and start a new discussion.
-  - name: CORTX Community Support
+    about: Have questions or need support for anything else? Please start a new discussion.
+  - name: CORTX community questions and support via Slack
     url: https://cortx.link/slack_invite
-    about: Join us on Slack for general CORTX questions and support.
+    about: Or please ask us on Slack.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Feature request for overall CORTX project
     url: https://github.com/Seagate/cortx/issues/new?assignees=&labels=enhancement&template=enhancement.yml

--- a/.github/ISSUE_TEMPLATE/enchancement.yml
+++ b/.github/ISSUE_TEMPLATE/enchancement.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Request a new feature or improvement specific to this CORTX component. Please check first to make sure this feature has not yet been requested.  
+description: Request a new feature or improvement specific to this CORTX component. Please first check to make sure this has not yet been requested.  
 labels: [enhancement]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/enchancement.yml
+++ b/.github/ISSUE_TEMPLATE/enchancement.yml
@@ -1,4 +1,4 @@
-name: Feature Request
+name: Feature request
 description: Request a new feature or improvement specific to this CORTX component. Please first check to make sure this has not yet been requested.  
 labels: [enhancement]
 body:


### PR DESCRIPTION
Also, trying to reduce any confusion about making an Issue specific to the cortx submodule (e.g. cortx-motr) versus general questions about the overall CORTX project.

To see how this will look in our various submodules, please review how this looks in the fork where I made these commits:
https://github.com/johnbent/.github/issues/new/choose